### PR TITLE
fix(asdf.fish): Make it work on OS X homebrew installation

### DIFF
--- a/conf.d/asdf.fish
+++ b/conf.d/asdf.fish
@@ -1,5 +1,7 @@
 if test -n "$ASDF_DATA_DIR" -a -d "$ASDF_DATA_DIR"
     source $ASDF_DATA_DIR/asdf.fish
-else if test -d ~/.asdf
+else if test -f ~/.asdf/asdf.fish
     source ~/.asdf/asdf.fish
+else if test -f /usr/local/opt/asdf/asdf.fish
+    source /usr/local/opt/asdf/asdf.fish
 end


### PR DESCRIPTION
If asdf is installed using homebrew, `~/.asdf` directory exists, but the `~/.asdf/asdf.fish` file does not.

The `asdf.fish` is stored then at `(brew --prefix asdf)/asdf.fish` path, which in most causes defaults to `/usr/local/opt/asdf/asdf.fish`. Hardcoding the path is better because running `brew --prefix` takes ~0.2-1s which would slow down shell a lot.

Related:
- https://github.com/dteoh/fish-homebrew-asdf/blob/master/conf.d/homebrew-asdf.fish
- https://github.com/asdf-vm/asdf/pull/554/files