### PR TITLE
Make it compatible with Brew 3 / Apple Silicon

### DIFF
--- a/conf.d/asdf.fish
+++ b/conf.d/asdf.fish
@@ -4,4 +4,6 @@ else if test -f ~/.asdf/asdf.fish
     source ~/.asdf/asdf.fish
 else if test -f /usr/local/opt/asdf/asdf.fish
     source /usr/local/opt/asdf/asdf.fish
+else if test -f /opt/homebrew/opt/asdf/asdf.fish
+    source /opt/homebrew/opt/asdf/asdf.fish
 end


### PR DESCRIPTION
The path for Brew changes for computers with Apple Silicon, this should fix it. I have checked the completion files and I don't think it's necessary to change anything

See https://brew.sh/2021/02/05/homebrew-3.0.0/