### PR TITLE
Support new location of asdf.fish

### DIFF
--- a/conf.d/asdf.fish
+++ b/conf.d/asdf.fish
@@ -6,4 +6,6 @@ else if test -f /usr/local/opt/asdf/asdf.fish
     source /usr/local/opt/asdf/asdf.fish
 else if test -f /opt/homebrew/opt/asdf/asdf.fish
     source /opt/homebrew/opt/asdf/asdf.fish
+else if test -f /opt/homebrew/opt/asdf/libexec/asdf.fish
+    source /opt/homebrew/opt/asdf/libexec/asdf.fish
 end


### PR DESCRIPTION
At some point Homebrew stopped moving asdf.fish into the base path.  This covers where it lives right this second, while https://github.com/rstacruz/fish-asdf/pull/5 seemed to work before.

* Homebrew 3.6.15
* asdf 0.11.0
* MacOS Montery 12.6.2 ARM64

