### PR TITLE
Use `ASDF_DIR` instead of `ASDF_DATA_DIR`

### DIFF
--- a/conf.d/asdf.fish
+++ b/conf.d/asdf.fish
@@ -1,5 +1,5 @@
-if test -n "$ASDF_DATA_DIR" -a -d "$ASDF_DATA_DIR"
-    source $ASDF_DATA_DIR/asdf.fish
+if test -n "$ASDF_DIR" -a -d "$ASDF_DIR"
+    source $ASDF_DIR/asdf.fish
 else if test -f ~/.asdf/asdf.fish
     source ~/.asdf/asdf.fish
 else if test -f /usr/local/opt/asdf/asdf.fish


### PR DESCRIPTION
`ASDF_DATA_DIR` is used to define a user write-able directory, typically `$HOME/.asdf`. 

However `asdf.fish` exists within the `$ASDF_DIR`.