### PR TITLE
Update asdf.fish -- adding `/usr/local/opt/asdf/libexec/asdf.fish` to the list of possible locations for the `asdf.fish` config file

### DIFF
--- a/conf.d/asdf.fish
+++ b/conf.d/asdf.fish
@@ -4,6 +4,8 @@ else if test -f ~/.asdf/asdf.fish
     source ~/.asdf/asdf.fish
 else if test -f /usr/local/opt/asdf/asdf.fish
     source /usr/local/opt/asdf/asdf.fish
+else if test -f /usr/local/opt/asdf/libexec/asdf.fish
+    source /usr/local/opt/asdf/libexec/asdf.fish
 else if test -f /opt/homebrew/opt/asdf/asdf.fish
     source /opt/homebrew/opt/asdf/asdf.fish
 else if test -f /opt/homebrew/opt/asdf/libexec/asdf.fish


### PR DESCRIPTION
Noticed my homebrewed asdf install was not shell-powered by `rstacruz/fish-asdf`, I realized my (non-tuned) Homebrew 4.2.8 version has put the `asdf.fish` file in `/usr/local/opt/asdf/libexec/asdf.fish` which is not listed in the possible sources of this plugin.

So here's me suggesting the change :) I've tested locally and it works.